### PR TITLE
Fix reading number of pending pods

### DIFF
--- a/tests-k8s/docker/tests-kube.sh
+++ b/tests-k8s/docker/tests-kube.sh
@@ -130,7 +130,7 @@ load_zones() {
   while [[ ${zones_ready} -eq 0 ]]; do
     sleep 5
 
-    local incoming=$(kubectl get pod | grep ' \(ContainerCreating|Pending\) ' | wc -l)
+    local incoming=$(kubectl get pod | grep -w 'ContainerCreating\|Pending' | wc -l)
     local running=$(kubectl get pod | grep "^zone[a-z0-9-]* *1/1 *Running" | wc -l)
 
     if [[ ${incoming} -eq 0 && ${running} -eq ${COUNT_ZONES} ]]; then


### PR DESCRIPTION
Up to this point the value of variable 'incoming' was always 0